### PR TITLE
Make telepoison reset parent span

### DIFF
--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -15,7 +15,6 @@ defmodule Telepoison do
 
   alias HTTPoison.Request
   alias OpenTelemetry.Tracer
-  require Logger
 
   @doc """
   Setups the opentelemetry instrumentation for Telepoison

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -15,6 +15,7 @@ defmodule Telepoison do
 
   alias HTTPoison.Request
   alias OpenTelemetry.Tracer
+  require Logger
 
   @doc """
   Setups the opentelemetry instrumentation for Telepoison
@@ -36,6 +37,7 @@ defmodule Telepoison do
   end
 
   def request(%Request{options: opts} = request) do
+    save_parent_ctx()
     span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> compute_default_span_name(request) end)
 
     attributes =
@@ -54,6 +56,7 @@ defmodule Telepoison do
     # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#status
     Tracer.set_attribute("http.status_code", status_code)
     Tracer.end_span()
+    restore_parent_ctx()
     status_code
   end
 
@@ -61,5 +64,17 @@ defmodule Telepoison do
     method_str = request.method |> Atom.to_string() |> String.upcase()
     %URI{authority: authority} = request.url |> process_request_url() |> URI.parse()
     "#{method_str} #{authority}"
+  end
+
+  @ctx_key {__MODULE__, :parent_ctx}
+  defp save_parent_ctx() do
+    ctx = Tracer.current_span_ctx()
+    Process.put(@ctx_key, ctx)
+  end
+
+  defp restore_parent_ctx() do
+    ctx = Process.get(@ctx_key, :undefined)
+    Process.delete(@ctx_key)
+    Tracer.set_current_span(ctx)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Telepoison.MixProject do
   def project do
     [
       app: :telepoison,
-      version: "1.0.0-rc.3",
+      version: "1.0.0-rc.4",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
In this PR the parent span is set when the telepoison span is completed.

This could also be implemented by ending the telepoison span and not the current span, but unfortunately I am not able to make the tests pass, so I decided to submit this PR first.

