### PR TITLE
[PRIMAUK-3186]: Inconsistent http client spans instrumentation due to usage of different Telepoison implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,9 @@ Telepoison.get!(url, headers, opts)
 
 `Telepoison.setup/1` takes a `Keyword list` that can configure if and how the `http.route` Open Telemetry metadata will be set per request using the `:infer_route` option.
 
-* If `:default` is provided then the out of the box, conservative inference provided by `Telepoison.URI.infer_route_from_request/1` is used to determine the inference.
+* If no value is provided then the out of the box, conservative inference provided by `Telepoison.URI.infer_route_from_request/1` is used to determine the inference
 
-* If an anonymous function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) is provided then that function is used to determine the inference.
-
-* If `:disabled` is provided then no inference is used.
-
-* If no value is provided, no inference is used.
+* If an function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) is provided then that function is used to determine the inference
 
 This can be overridden per each call to `Telepoison.request/1` derived functions (`Telepoison.get/3`, `Telepoison.get!/3` etc.)
 
@@ -45,9 +41,9 @@ the `Keyword list` `opts` parameter (or the `HTTPoison.Request` `options` `Keywo
 * `:ot_attributes` - a list of `{name, value}` `tuple` attributes that will be added to the span.
 * `:ot_resource_route` - sets the `http.route` attribute, depending on the value provided.
 
-If the value is a string or an anonymous function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) that is used to set the attribute.
+If the value is a string or an function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) that is used to set the attribute
 
-If `:infer` is provided, then either the out of the box or custom inference discussed within the Configuration section is used to set the attribute, unless it has been disabled.
+If `:infer` is provided, then the function discussed within the *Configuration* section is used to set the attribute
 
 **It is highly recommended** to supply the `:ot_resource_route` explicitly as either a string or an anonymous function with an arity of 1.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These typically start with `:ot_`
 
 * `:ot_span_name` sets the span name
 * `:ot_attributes` additional span attributes that will be added to the span. Should be a list of {name, value} tuples.
-* `:resource_route` sets the `http.route` attribute explicitly. This will be inferred automatically if not provided.
+* `:resource_route` sets the `http.route` attribute explicitly. This can be inferred automatically by passing in `:infer` as the value instead.
 
 
 Example:
@@ -39,8 +39,9 @@ Telepoison.get!(
 )
 ```
 
-In the example above, if `:resource_route` was not provided, it would be inferred as "/user/:subpath". As evidenced, this fallback is
-rather conservative, so it is highly recommended to supply the `:resource_route` explicitly.
+In the example above, if `:infer` was provided as the value for the `:resource_route` option, it would be inferred as "/user/:subpath".
+
+As is evident, this fallback is rather conservative, so it is highly recommended to supply the `:resource_route` explicitly.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -21,21 +21,26 @@ Telepoison.get!(url, headers, opts)
 ```
 
 Additionally, telepoison adds some options that can be passed in the `opts` HTTPoison argument to set OpenTelemetry-related stuff.
-These start with `:ot_`
+These typically start with `:ot_`
 
 * `:ot_span_name` sets the span name
 * `:ot_attributes` additional span attributes that will be added to the span. Should be a list of {name, value} tuples.
+* `:resource_route` sets the `http.route` attribute explicitly. This will be inferred automatically if not provided.
 
 
 Example:
 ```elixir
 Telepoison.get!(
-  "en.wikipedia.org",
+  "https://www.example.com/user/list",
   [],
-  ot_span_name: "fetch wikipedia homepage",
-  ot_attributes: [{"wikipedia.language", "en"}]
+  ot_span_name: "list example users",
+  ot_attributes: [{"example.language", "en"}],
+  resource_route: "/user/list"
 )
 ```
+
+In the example above, if `:resource_route` was not provided, it would be inferred as "/user/:subpath". As evidenced, this fallback is
+rather conservative, so it is highly recommended to supply the `:resource_route` explicitly.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Telepoison.get!(url, headers, opts)
 
 ## Configuration
 
-`Telepoison.setup/1` takes a `Keyword list` that can configure if and how the `http.route` Open Telemetry metadata will be set per request using the `:infer_route` option
+`Telepoison.setup/1` takes a `Keyword list` that can configure how the `http.route` Open Telemetry metadata will be set per request using the `:infer_route` option
 
 * If no value is provided then the out of the box, conservative inference provided by `Telepoison.URI.infer_route_from_request/1` is used to determine the inference
 
 * If a function with an arity of 1 (the argument given being the `t:HTTPoison.Request/0` `request`) is provided then that function is used to determine the inference
 
-This can be overridden per each call to `Telepoison.request/1` derived functions (`Telepoison.get/3`, `Telepoison.get!/3`, `Telepoison.post/3` etc.)
+This can be overridden per each call to Telepoison functions that wrap `Telepoison.request/1`, such as `Telepoison.get/3`, `Telepoison.get!/3`, `Telepoison.post/3` etc.
 
 See here for [examples](#Examples)
 
 ## Open Telemetry integration
 
 Additionally, `Telepoison` provides some options that can be added to each derived function via
-the `Keyword list` `opts` parameter (or the `HTTPoison.Request` `options` `Keyword list` if calling `Telepoison.Request/1` directly). These are prefixed with `:ot_`.
+the `Keyword list` `opts` parameter (or the `t:HTTPoison.Request/0` `Keyword list` `options` parameter if calling `Telepoison.Request/1` directly). These are prefixed with `:ot_`.
 
 * `:ot_span_name` - sets the span name.
 * `:ot_attributes` - a list of `{name, value}` `tuple` attributes that will be added to the span.
@@ -97,8 +97,6 @@ Telepoison.setup()
 Telepoison.get!(
   "https://www.example.com/user/list",
   [],
-  ot_span_name: "list example users",
-  ot_attributes: [{"example.language", "en"}],
   ot_resource_route: "my secret path"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Telepoison.get!(url, headers, opts)
 ```
 
 Additionally, telepoison adds some options that can be passed in the `opts` HTTPoison argument to set OpenTelemetry-related stuff.
-These typically start with `:ot_`
+These start with `:ot_`
 
 * `:ot_span_name` sets the span name
 * `:ot_attributes` additional span attributes that will be added to the span. Should be a list of {name, value} tuples.
-* `:resource_route` sets the `http.route` attribute explicitly. This can be inferred automatically by passing in `:infer` as the value instead.
+* `:ot_resource_route` sets the `http.route` attribute explicitly. This can be inferred automatically by passing in `:infer` as the value instead.
 
 
 Example:
@@ -35,13 +35,13 @@ Telepoison.get!(
   [],
   ot_span_name: "list example users",
   ot_attributes: [{"example.language", "en"}],
-  resource_route: "/user/list"
+  ot_resource_route: "/user/list"
 )
 ```
 
-In the example above, if `:infer` was provided as the value for the `:resource_route` option, it would be inferred as "/user/:subpath".
+In the example above, if `:infer` was provided as the value for the `:ot_resource_route` option, it would be inferred as "/user/:subpath".
 
-As is evident, this fallback is rather conservative, so it is highly recommended to supply the `:resource_route` explicitly.
+As is evident, this fallback is rather conservative, so it is highly recommended to supply the `:ot_resource_route` explicitly.
 
 ## How it works
 

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -41,9 +41,10 @@ defmodule Telepoison do
   See `HTTPoison.request/1` for further details regarding `request` options.
 
   Will attempt to automatically set the `http.route` Open Telemetry metadata attribute by
-  removing the last part of the `request.url`, since this part typically contains dynamic data.
+  removing the last part of the `request.url` (since this part typically contains dynamic data)
+  if the `resource_route` option is set to `:infer`.
 
-  If this behavior is not desirable, it can be set directly by using the `:resource_route` optional parameter.
+  If this behavior is not desirable, it can be set directly by using the aforementioned option.
 
     ## Examples
 
@@ -51,7 +52,8 @@ defmodule Telepoison do
       ...> method: :post,
       ...> url: "https://www.example.com/users/edit/2",
       ...> body: ~s({"foo": 3}),
-      ...> headers: [{"Accept", "application/json"}]}
+      ...> headers: [{"Accept", "application/json"}],
+      ...> options: [resource_route: :infer]}
       iex> Telepoison.request(request)
 
   """

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -63,7 +63,7 @@ defmodule Telepoison do
     span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> compute_default_span_name(request) end)
 
     resource_route =
-      case Keyword.get(opts, :resource_route) do
+      case Keyword.get(opts, :ot_resource_route) do
         :infer ->
           Telepoison.URI.infer_route_from_request(request)
 

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -35,14 +35,45 @@ defmodule Telepoison do
     :otel_propagator_text_map.inject(headers)
   end
 
+  @doc ~S"""
+  Performs a request using Telepoison with the provided `request` options.
+
+  See `HTTPoison.request/1` for further details regarding `request` options.
+
+  Will attempt to automatically set the `http.route` Open Telemetry metadata attribute by
+  removing the last part of the `request.url`, since this part typically contains dynamic data.
+
+  If this behavior is not desirable, it can be set directly by using the `:resource_route` optional parameter.
+
+    ## Examples
+
+      iex> request = %HTTPoison.Request{
+      ...> method: :post,
+      ...> url: "https://www.example.com/users/edit/2",
+      ...> body: ~s({"foo": 3}),
+      ...> headers: [{"Accept", "application/json"}]}
+      iex> Telepoison.request(request)
+
+  """
   def request(%Request{options: opts} = request) do
     save_parent_ctx()
+
     span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> compute_default_span_name(request) end)
+
+    resource_route =
+      case Keyword.get(opts, :resource_route) do
+        nil ->
+          Telepoison.URI.infer_route(request)
+
+        route ->
+          route
+      end
 
     attributes =
       [
         {"http.method", request.method |> Atom.to_string() |> String.upcase()},
-        {"http.url", request.url}
+        {"http.url", request.url},
+        {"http.route", resource_route}
       ] ++ Keyword.get(opts, :ot_attributes, [])
 
     new_ctx = Tracer.start_span(span_name, %{kind: :client, attributes: attributes})

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -62,8 +62,8 @@ defmodule Telepoison do
 
     resource_route =
       case Keyword.get(opts, :resource_route) do
-        nil ->
-          Telepoison.URI.infer_route(request)
+        :infer ->
+          Telepoison.URI.infer_route_from_request(request)
 
         route ->
           route

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -74,9 +74,12 @@ defmodule Telepoison do
     attributes =
       [
         {"http.method", request.method |> Atom.to_string() |> String.upcase()},
-        {"http.url", request.url},
-        {"http.route", resource_route}
-      ] ++ Keyword.get(opts, :ot_attributes, [])
+        {"http.url", request.url}
+      ] ++
+        Keyword.get(opts, :ot_attributes, []) ++
+        if resource_route != nil,
+          do: [{"http.route", resource_route}],
+          else: []
 
     new_ctx = Tracer.start_span(span_name, %{kind: :client, attributes: attributes})
     Tracer.set_current_span(new_ctx)

--- a/lib/uri.ex
+++ b/lib/uri.ex
@@ -1,0 +1,43 @@
+defmodule Telepoison.URI do
+  @moduledoc """
+  Exposes a function to normalise URIs in a format suitable for usage as Open Telemetry metadata.
+  """
+
+  alias HTTPoison.Request
+
+  @default_route "/"
+
+  @spec infer_route(String.t() | URI.t() | Request.t()) :: String.t()
+  @doc """
+  Infers the route of the provided `uri`, returned in a format suitable for usage as Open Telemetry metadata.
+  """
+  def infer_route(uri) when is_nil(uri) or byte_size(uri) <= 1, do: @default_route
+
+  def infer_route(%URI{path: path}) when is_nil(path) or byte_size(path) <= 1, do: @default_route
+
+  def infer_route(%Request{url: url}) when is_nil(url) or byte_size(url) <= 1, do: @default_route
+
+  def infer_route(uri) when is_binary(uri), do: uri |> URI.parse() |> infer_route()
+
+  def infer_route(%Request{url: url}), do: infer_route(url)
+
+  def infer_route(%URI{path: path}) do
+    segments =
+      path
+      |> String.split("/")
+      |> Enum.filter(&(byte_size(String.trim(&1)) > 0))
+
+    case Enum.count(segments) do
+      1 ->
+        "/#{Enum.take(segments, 1)}"
+
+      count when count > 1 ->
+        segments
+        |> Enum.take(1)
+        |> (&"/#{&1}/:subpath").()
+
+      _ ->
+        @default_route
+    end
+  end
+end

--- a/lib/uri.ex
+++ b/lib/uri.ex
@@ -7,37 +7,34 @@ defmodule Telepoison.URI do
 
   @default_route "/"
 
-  @spec infer_route(String.t() | URI.t() | Request.t()) :: String.t()
+  @spec infer_route_from_request(Request.t()) :: binary()
   @doc """
-  Infers the route of the provided `uri`, returned in a format suitable for usage as Open Telemetry metadata.
+  Infers the route of the provided `HTTPoison.Request`, returned in a format suitable for usage as Open Telemetry metadata.
   """
-  def infer_route(uri) when is_nil(uri) or byte_size(uri) <= 1, do: @default_route
+  def infer_route_from_request(%Request{url: url}) when is_binary(url), do: infer_route_from_url(url)
 
-  def infer_route(%URI{path: path}) when is_nil(path) or byte_size(path) <= 1, do: @default_route
+  def infer_route_from_request(%Request{}), do: @default_route
 
-  def infer_route(%Request{url: url}) when is_nil(url) or byte_size(url) <= 1, do: @default_route
-
-  def infer_route(uri) when is_binary(uri), do: uri |> URI.parse() |> infer_route()
-
-  def infer_route(%Request{url: url}), do: infer_route(url)
-
-  def infer_route(%URI{path: path}) do
-    segments =
-      path
-      |> String.split("/")
-      |> Enum.filter(&(byte_size(String.trim(&1)) > 0))
-
-    case Enum.count(segments) do
-      1 ->
-        "/#{Enum.take(segments, 1)}"
-
-      count when count > 1 ->
-        segments
-        |> Enum.take(1)
-        |> (&"/#{&1}/:subpath").()
-
-      _ ->
+  @spec infer_route_from_url(binary()) :: binary()
+  defp infer_route_from_url(url) when is_binary(url) do
+    url
+    |> URI.parse()
+    |> Map.get(:path, "/")
+    |> case do
+      nil ->
         @default_route
+
+      value ->
+        case String.split(value, "/", parts: 2, trim: true) do
+          [] ->
+            @default_route
+
+          [path] ->
+            "/#{path}"
+
+          [path, _] ->
+            "/#{path}/:subpath"
+        end
     end
   end
 end

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -67,10 +67,10 @@ defmodule TelepoisonTest do
   end
 
   test "resource route can be implicitly inferred by Telepoison invocation" do
-    Telepoison.get!("http://localhost:8000/user/edit/24")
+    Telepoison.get!("http://localhost:8000/user/edit/24", [], resource_route: :infer)
 
     assert_receive {:span, span(attributes: attributes)}, 1000
-    assert {"http.route", "/user/:subpath"}
+    assert {"http.route", "/user/:subpath"} in elem(attributes, 4)
   end
 
   def flush_mailbox do

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -27,7 +27,7 @@ defmodule TelepoisonTest do
     assert_receive {:span, span(attributes: attributes_record)}
     attributes = elem(attributes_record, 4)
 
-    assert ["http.method", "http.route", "http.status_code", "http.url"] ==
+    assert ["http.method", "http.status_code", "http.url"] ==
              attributes |> Map.keys() |> Enum.sort()
 
     assert {"http.method", "GET"} in attributes

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -10,78 +10,75 @@ defmodule TelepoisonTest do
     Record.defrecord(name, spec)
   end
 
-  setup_all do
-    Telepoison.setup()
-    :ok
-  end
-
   setup do
     flush_mailbox()
     :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
     :ok
   end
 
-  test "standard http client span attribute are set in span" do
-    Telepoison.get!("http://localhost:8000")
-
-    assert_receive {:span, span(attributes: attributes_record)}
-    attributes = elem(attributes_record, 4)
-
-    assert ["http.method", "http.status_code", "http.url"] ==
-             attributes |> Map.keys() |> Enum.sort()
-
-    assert {"http.method", "GET"} in attributes
-  end
-
-  test "traceparent header is injected when no headers" do
-    %HTTPoison.Response{request: %{headers: headers}} = Telepoison.get!("http://localhost:8000")
-    assert "traceparent" in Enum.map(headers, &elem(&1, 0))
-  end
-
-  test "traceparent header is injected when list headers" do
-    %HTTPoison.Response{request: %{headers: headers}} =
-      Telepoison.get!("http://localhost:8000", [{"Accept", "application/json"}])
-
-    assert "traceparent" in Enum.map(headers, &elem(&1, 0))
-  end
-
-  test "traceparent header is injected to user-supplied map headers" do
-    %HTTPoison.Response{request: %{headers: headers}} =
-      Telepoison.get!("http://localhost:8000", %{"Accept" => "application/json"})
-
-    assert "traceparent" in Enum.map(headers, &elem(&1, 0))
-  end
-
-  test "additional span attributes can be passed to Telepoison invocation" do
-    Telepoison.get!("http://localhost:8000", [], ot_attributes: [{"app.callname", "mariorossi"}])
-
-    assert_receive {:span, span(attributes: attributes)}, 1000
-    assert confirm_attributes(attributes, {"app.callname", "mariorossi"})
-  end
-
-  test "resource route can be explicitly passed to Telepoison invocation as a string" do
-    Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: "/user/edit")
-
-    assert_receive {:span, span(attributes: attributes)}, 1000
-    assert confirm_attributes(attributes, {"http.route", "/user/edit"})
-  end
-
-  test "resource route can be explicitly passed to Telepoison invocation as a function" do
-    infer_fn = fn request -> URI.parse(request.url).path end
-
-    Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: infer_fn)
-
-    assert_receive {:span, span(attributes: attributes)}, 1000
-    assert confirm_attributes(attributes, {"http.route", "/user/edit/24"})
-  end
-
-  describe "Telepoison setup" do
+  describe "Telepoison setup without additional configuration" do
     setup do
-      Telepoison.stop()
+      Telepoison.setup()
     end
 
+    test "standard http client span attribute are set in span" do
+      Telepoison.get!("http://localhost:8000")
+
+      assert_receive {:span, span(attributes: attributes_record)}
+      attributes = elem(attributes_record, 4)
+
+      assert ["http.method", "http.status_code", "http.url"] ==
+               attributes |> Map.keys() |> Enum.sort()
+
+      assert {"http.method", "GET"} in attributes
+    end
+
+    test "traceparent header is injected when no headers" do
+      %HTTPoison.Response{request: %{headers: headers}} = Telepoison.get!("http://localhost:8000")
+      assert "traceparent" in Enum.map(headers, &elem(&1, 0))
+    end
+
+    test "traceparent header is injected when list headers" do
+      %HTTPoison.Response{request: %{headers: headers}} =
+        Telepoison.get!("http://localhost:8000", [{"Accept", "application/json"}])
+
+      assert "traceparent" in Enum.map(headers, &elem(&1, 0))
+    end
+
+    test "traceparent header is injected to user-supplied map headers" do
+      %HTTPoison.Response{request: %{headers: headers}} =
+        Telepoison.get!("http://localhost:8000", %{"Accept" => "application/json"})
+
+      assert "traceparent" in Enum.map(headers, &elem(&1, 0))
+    end
+
+    test "additional span attributes can be passed to Telepoison invocation" do
+      Telepoison.get!("http://localhost:8000", [], ot_attributes: [{"app.callname", "mariorossi"}])
+
+      assert_receive {:span, span(attributes: attributes)}, 1000
+      assert confirm_attributes(attributes, {"app.callname", "mariorossi"})
+    end
+
+    test "resource route can be explicitly passed to Telepoison invocation as a string" do
+      Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: "/user/edit")
+
+      assert_receive {:span, span(attributes: attributes)}, 1000
+      assert confirm_attributes(attributes, {"http.route", "/user/edit"})
+    end
+
+    test "resource route can be explicitly passed to Telepoison invocation as a function" do
+      infer_fn = fn request -> URI.parse(request.url).path end
+
+      Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: infer_fn)
+
+      assert_receive {:span, span(attributes: attributes)}, 1000
+      assert confirm_attributes(attributes, {"http.route", "/user/edit/24"})
+    end
+  end
+
+  describe "Telepoison setup with additional configuration" do
     test "resource route can be implicitly inferred by Telepoison invocation by default function" do
-      Telepoison.setup(infer_source: :default)
+      Telepoison.setup(infer_route: :default)
 
       Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: :infer)
 
@@ -90,14 +87,16 @@ defmodule TelepoisonTest do
     end
 
     test "resource route can be implicitly inferred by Telepoison invocation by explicitly configured function" do
-      infer_fn = fn request -> URI.parse(request.url).path end
+      infer_fn = fn
+        %HTTPoison.Request{} = request -> URI.parse(request.url).path
+      end
 
-      Telepoison.setup(infer_source: infer_fn)
+      Telepoison.setup(infer_route: infer_fn)
 
       Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: :infer)
 
       assert_receive {:span, span(attributes: attributes)}, 1000
-      assert confirm_attributes(attributes, {"http.route", "/user/:subpath"})
+      assert confirm_attributes(attributes, {"http.route", "/user/edit/24"})
     end
   end
 

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -27,7 +27,7 @@ defmodule TelepoisonTest do
     assert_receive {:span, span(attributes: attributes_record)}
     attributes = elem(attributes_record, 4)
 
-    assert ["http.method", "http.status_code", "http.url"] ==
+    assert ["http.method", "http.route", "http.status_code", "http.url"] ==
              attributes |> Map.keys() |> Enum.sort()
 
     assert {"http.method", "GET"} in attributes
@@ -57,6 +57,20 @@ defmodule TelepoisonTest do
 
     assert_receive {:span, span(attributes: attributes)}, 1000
     assert {"app.callname", "mariorossi"} in elem(attributes, 4)
+  end
+
+  test "resource route can be explicitly passed to Telepoison invocation" do
+    Telepoison.get!("http://localhost:8000/user/edit/24", [], resource_route: "/user/edit")
+
+    assert_receive {:span, span(attributes: attributes)}, 1000
+    assert {"http.route", "/user/edit"} in elem(attributes, 4)
+  end
+
+  test "resource route can be implicitly inferred by Telepoison invocation" do
+    Telepoison.get!("http://localhost:8000/user/edit/24")
+
+    assert_receive {:span, span(attributes: attributes)}, 1000
+    assert {"http.route", "/user/:subpath"}
   end
 
   def flush_mailbox do

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -60,14 +60,14 @@ defmodule TelepoisonTest do
   end
 
   test "resource route can be explicitly passed to Telepoison invocation" do
-    Telepoison.get!("http://localhost:8000/user/edit/24", [], resource_route: "/user/edit")
+    Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: "/user/edit")
 
     assert_receive {:span, span(attributes: attributes)}, 1000
     assert confirm_attributes(attributes, {"http.route", "/user/edit"})
   end
 
   test "resource route can be implicitly inferred by Telepoison invocation" do
-    Telepoison.get!("http://localhost:8000/user/edit/24", [], resource_route: :infer)
+    Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: :infer)
 
     assert_receive {:span, span(attributes: attributes)}, 1000
     assert confirm_attributes(attributes, {"http.route", "/user/:subpath"})

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -56,21 +56,21 @@ defmodule TelepoisonTest do
     Telepoison.get!("http://localhost:8000", [], ot_attributes: [{"app.callname", "mariorossi"}])
 
     assert_receive {:span, span(attributes: attributes)}, 1000
-    assert {"app.callname", "mariorossi"} in elem(attributes, 4)
+    assert confirm_attributes(attributes, {"app.callname", "mariorossi"})
   end
 
   test "resource route can be explicitly passed to Telepoison invocation" do
     Telepoison.get!("http://localhost:8000/user/edit/24", [], resource_route: "/user/edit")
 
     assert_receive {:span, span(attributes: attributes)}, 1000
-    assert {"http.route", "/user/edit"} in elem(attributes, 4)
+    assert confirm_attributes(attributes, {"http.route", "/user/edit"})
   end
 
   test "resource route can be implicitly inferred by Telepoison invocation" do
     Telepoison.get!("http://localhost:8000/user/edit/24", [], resource_route: :infer)
 
     assert_receive {:span, span(attributes: attributes)}, 1000
-    assert {"http.route", "/user/:subpath"} in elem(attributes, 4)
+    assert confirm_attributes(attributes, {"http.route", "/user/:subpath"})
   end
 
   def flush_mailbox do
@@ -79,5 +79,14 @@ defmodule TelepoisonTest do
     after
       10 -> :ok
     end
+  end
+
+  defp confirm_attributes(attributes, attributes_to_confirm) do
+    attributes
+    |> Tuple.to_list()
+    |> Enum.filter(&is_map/1)
+    |> Enum.any?(fn map ->
+      attributes_to_confirm in map
+    end)
   end
 end

--- a/test/uri_test.exs
+++ b/test/uri_test.exs
@@ -1,0 +1,131 @@
+defmodule Telepoison.URITest do
+  @moduledoc """
+  Tests for `Telepoison.URI`
+  """
+
+  alias HTTPoison.Request
+
+  use ExUnit.Case
+
+  alias Telepoison.URI, as: UtilsURI
+
+  @base_uri "https://www.test.com/"
+
+  describe "infer_route/1" do
+    test "Nil URI is inferred as a route of '/'" do
+      result = UtilsURI.infer_route(nil)
+
+      assert result == "/"
+    end
+
+    test "URI consisiting of whitespace is inferred as a route of '/'" do
+      result = UtilsURI.infer_route("")
+
+      assert result == "/"
+    end
+
+    test "URI '#{@base_uri}user/edit/24' is inferred as a route of '/user/:subpath'" do
+      result = UtilsURI.infer_route("#{@base_uri}user/edit/24")
+
+      assert result == "/user/:subpath"
+    end
+
+    test "URI '#{@base_uri}user/24' is inferred as a route of '/user:subpath'" do
+      result = UtilsURI.infer_route("#{@base_uri}user/24")
+
+      assert result == "/user/:subpath"
+    end
+
+    test "URI '#{@base_uri}user' is inferred as route of '/user'" do
+      result = UtilsURI.infer_route("#{@base_uri}user")
+
+      assert result == "/user"
+    end
+
+    test "URI '#{@base_uri}' is inferred as route of '/'" do
+      result = UtilsURI.infer_route("#{@base_uri}")
+
+      assert result == "/"
+    end
+
+    test "Nil URI path is inferred as a route of '/'" do
+      uri = %URI{path: nil}
+
+      result = UtilsURI.infer_route(uri)
+
+      assert result == "/"
+    end
+
+    test "URI path consisiting of whitespace is inferred as a route of '/'" do
+      uri = %URI{path: ""}
+
+      result = UtilsURI.infer_route(uri)
+
+      assert result == "/"
+    end
+
+    test "URI path '/user/edit/24' is inferred as a route of '/user/:subpath'" do
+      uri = %URI{path: "/user/edit/24"}
+
+      result = UtilsURI.infer_route(uri)
+
+      assert result == "/user/:subpath"
+    end
+
+    test "URI path '/user/24' is inferred as a route of '/user:subpath'" do
+      uri = %URI{path: "/user/24"}
+
+      result = UtilsURI.infer_route(uri)
+
+      assert result == "/user/:subpath"
+    end
+
+    test "URI path 'user' is inferred as route of '/user'" do
+      uri = %URI{path: "user"}
+
+      result = UtilsURI.infer_route(uri)
+
+      assert result == "/user"
+    end
+
+    test "Nil Request URL is inferred as a route of '/'" do
+      request = %Request{url: nil}
+
+      result = UtilsURI.infer_route(request)
+
+      assert result == "/"
+    end
+
+    test "Request URL consisiting of whitespace is inferred as a route of '/'" do
+      request = %Request{url: ""}
+
+      result = UtilsURI.infer_route(request)
+
+      assert result == "/"
+    end
+
+    test "Request URL '/user/edit/24' is inferred as a route of '/user/:subpath'" do
+      request = %Request{url: "/user/edit/24"}
+
+      result = UtilsURI.infer_route(request)
+
+      assert result == "/user/:subpath"
+    end
+
+    test "Request URL '/user/24' is inferred as a route of '/user:subpath'" do
+      request = %Request{url: "/user/24"}
+
+      result = UtilsURI.infer_route(request)
+
+      assert result == "/user/:subpath"
+    end
+
+    test "Request URL 'user' is inferred as route of '/user'" do
+      request = %Request{url: "user"}
+
+      result = UtilsURI.infer_route(request)
+
+      assert result == "/user"
+    end
+  end
+end

--- a/test/uri_test.exs
+++ b/test/uri_test.exs
@@ -9,121 +9,40 @@ defmodule Telepoison.URITest do
 
   alias Telepoison.URI, as: UtilsURI
 
-  @base_uri "https://www.test.com/"
+  @base_uri "https://www.test.com"
 
-  describe "infer_route/1" do
-    test "Nil URI is inferred as a route of '/'" do
-      result = UtilsURI.infer_route(nil)
-
-      assert result == "/"
-    end
-
-    test "URI consisiting of whitespace is inferred as a route of '/'" do
-      result = UtilsURI.infer_route("")
-
-      assert result == "/"
-    end
-
-    test "URI '#{@base_uri}user/edit/24' is inferred as a route of '/user/:subpath'" do
-      result = UtilsURI.infer_route("#{@base_uri}user/edit/24")
-
-      assert result == "/user/:subpath"
-    end
-
-    test "URI '#{@base_uri}user/24' is inferred as a route of '/user:subpath'" do
-      result = UtilsURI.infer_route("#{@base_uri}user/24")
-
-      assert result == "/user/:subpath"
-    end
-
-    test "URI '#{@base_uri}user' is inferred as route of '/user'" do
-      result = UtilsURI.infer_route("#{@base_uri}user")
-
-      assert result == "/user"
-    end
-
-    test "URI '#{@base_uri}' is inferred as route of '/'" do
-      result = UtilsURI.infer_route("#{@base_uri}")
-
-      assert result == "/"
-    end
-
-    test "Nil URI path is inferred as a route of '/'" do
-      uri = %URI{path: nil}
-
-      result = UtilsURI.infer_route(uri)
-
-      assert result == "/"
-    end
-
-    test "URI path consisiting of whitespace is inferred as a route of '/'" do
-      uri = %URI{path: ""}
-
-      result = UtilsURI.infer_route(uri)
-
-      assert result == "/"
-    end
-
-    test "URI path '/user/edit/24' is inferred as a route of '/user/:subpath'" do
-      uri = %URI{path: "/user/edit/24"}
-
-      result = UtilsURI.infer_route(uri)
-
-      assert result == "/user/:subpath"
-    end
-
-    test "URI path '/user/24' is inferred as a route of '/user:subpath'" do
-      uri = %URI{path: "/user/24"}
-
-      result = UtilsURI.infer_route(uri)
-
-      assert result == "/user/:subpath"
-    end
-
-    test "URI path 'user' is inferred as route of '/user'" do
-      uri = %URI{path: "user"}
-
-      result = UtilsURI.infer_route(uri)
-
-      assert result == "/user"
-    end
-
-    test "Nil Request URL is inferred as a route of '/'" do
-      request = %Request{url: nil}
-
-      result = UtilsURI.infer_route(request)
-
-      assert result == "/"
-    end
-
+  describe "infer_route_from_request/1" do
     test "Request URL consisiting of whitespace is inferred as a route of '/'" do
       request = %Request{url: ""}
 
-      result = UtilsURI.infer_route(request)
+      result = UtilsURI.infer_route_from_request(request)
 
       assert result == "/"
     end
 
-    test "Request URL '/user/edit/24' is inferred as a route of '/user/:subpath'" do
-      request = %Request{url: "/user/edit/24"}
+    test "Request URL '#{@base_uri}/user/edit/24' is inferred as a route of '/user/:subpath'" do
+      url = "#{@base_uri}/user/edit/24"
+      request = %Request{url: url}
 
-      result = UtilsURI.infer_route(request)
-
-      assert result == "/user/:subpath"
-    end
-
-    test "Request URL '/user/24' is inferred as a route of '/user:subpath'" do
-      request = %Request{url: "/user/24"}
-
-      result = UtilsURI.infer_route(request)
+      result = UtilsURI.infer_route_from_request(request)
 
       assert result == "/user/:subpath"
     end
 
-    test "Request URL 'user' is inferred as route of '/user'" do
-      request = %Request{url: "user"}
+    test "Request URL '#{@base_uri}/user/24' is inferred as a route of '/user/:subpath'" do
+      url = "#{@base_url}/user/24"
+      request = %Request{url: url}
 
-      result = UtilsURI.infer_route(request)
+      result = UtilsURI.infer_route_from_request(request)
+
+      assert result == "/user/:subpath"
+    end
+
+    test "Request URL #{@base_uri}/'user' is inferred as route of '/user'" do
+      url = "#{@base_uri}/user"
+      request = %Request{url: url}
+
+      result = UtilsURI.infer_route_from_request(request)
 
       assert result == "/user"
     end

--- a/test/uri_test.exs
+++ b/test/uri_test.exs
@@ -30,7 +30,7 @@ defmodule Telepoison.URITest do
     end
 
     test "Request URL '#{@base_uri}/user/24' is inferred as a route of '/user/:subpath'" do
-      url = "#{@base_url}/user/24"
+      url = "#{@base_uri}/user/24"
       request = %Request{url: url}
 
       result = UtilsURI.infer_route_from_request(request)


### PR DESCRIPTION
* Updates based off this [PR](https://github.com/primait/prima-pulumi/pull/96#issuecomment-1280117786) comment
* Adds the ability to explicitly set the `http.route` Open Telemetry metadata attribute with a sensible default if not set
* Updates `Telepoison.request` documentation

**TODO:**

- [x] Add tests

* Added

- [x] How does `Telepoison.get` etc. interact with `Telepoison.request`, as `Telepoison.request` doesn't seem to be explicitly called often within Stonehenge?

* Via meta magic and function overrides

- [x] Remove the `http.url` Open Telemetry metadata attribute, as this may contain sensitive data?
* Kept for now

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMAUK-3186
