### PR TITLE
Fix OTLP exporter failed to initialize error in test

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,5 @@
 import Config
 
 config :opentelemetry,
-  tracer: :otel_tracer_default,
-  processors: [{:otel_batch_processor, %{scheduled_delay_ms: 1}}]
+  traces_exporter: :none,
+  processors: [{:otel_simple_processor, %{}}]

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -14,7 +14,7 @@ defmodule TelepoisonTest do
 
   setup do
     flush_mailbox()
-    :otel_batch_processor.set_exporter(:otel_exporter_pid, self())
+    :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
     :ok
   end
 


### PR DESCRIPTION
Example: https://drone-1.prima.it/primait/telepoison/192/1/10
Taken from: https://opentelemetry.io/docs/instrumentation/erlang/testing/