### PR TITLE
[PRIMAUK-3641]: Telepoison - opt out of otel http route inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If the value is a string or an function with an arity of 1 (the `t:HTTPoison.Req
 
 If `:infer` is provided, then the function discussed within the [Configuration](#Configuration) section is used to set the attribute
 
+If the atom `:ignore` is provided then the `http.route` attribute is ignored entirely
+
 **It is highly recommended** to supply the `:ot_resource_route` explicitly as either a string or a function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) 
 
 ## Examples
@@ -106,6 +108,22 @@ In the example above:
 * `"my secret path"` is passed as the value for `:ot_resource_route` `Keyword list` option
 
 Given the above, the `http.route` attribute will be set as *my secret path*
+
+```elixir
+Telepoison.setup()
+
+Telepoison.get!(
+  "https://www.example.com/user/list",
+  [],
+  ot_resource_route: :ignore
+)
+```
+
+In the example above:
+* `Telepoison.setup/1` is called with no `Keyword list` options
+* `:ignore` is passed as the value for `:ot_resource_route` `Keyword list` option
+
+Given the above, the `http.route` attribute will not be set to any value
 
 ## How it works
 

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -81,6 +81,8 @@ defmodule Telepoison do
   If this behavior is not desirable, it can be set directly as a string or a function
   with an arity of 1 (the `t:HTTPoison.Request/0` `request`) by using the aforementioned `:ot_resource_route` option.
 
+  It can also be circumvented entirely by suppling `:ignore`  instead.
+
     ## Examples
 
       iex> Telepoison.setup()
@@ -120,6 +122,15 @@ defmodule Telepoison do
       ...> body: ~s({"foo": 3}),
       ...> headers: [{"Accept", "application/json"}],
       ...> options: [ot_resource_route: infer_fn]}
+      iex> Telepoison.request(request)
+
+      iex> Telepoison.setup()
+      iex> request = %HTTPoison.Request{
+      ...> method: :post,
+      ...> url: "https://www.example.com/users/edit/2",
+      ...> body: ~s({"foo": 3}),
+      ...> headers: [{"Accept", "application/json"}],
+      ...> options: [ot_resource_route: :ignore]}
       iex> Telepoison.request(request)
 
   """

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -129,7 +129,7 @@ defmodule Telepoison do
     span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> compute_default_span_name(request) end)
 
     resource_route =
-      case Keyword.get(opts, :ot_resource_route) do
+      case Keyword.get(opts, :ot_resource_route, :ignore) do
         route when is_binary(route) ->
           route
 
@@ -145,8 +145,12 @@ defmodule Telepoison do
             end
           )
 
-        _ ->
+        :ignore ->
           nil
+
+        _ ->
+          raise ArgumentError,
+                "The :ot_resource_route keyword option value must either be a binary or the :infer or :ignore atom"
       end
 
     attributes =

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -215,7 +215,7 @@ defmodule Telepoison do
 
       _ ->
         raise ArgumentError,
-              "The :ot_resource_route keyword option value must either be a binary or the :infer or :ignore atom"
+              "The :ot_resource_route keyword option value must either be a binary, a function with an arity of 1 or the :infer or :ignore atom"
     end
   end
 end


### PR DESCRIPTION
- Improves input handling
- Adds the ability to opt out of resource route inference locally

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMAUK-3641

