### PR TITLE
Add net.peer.name attribute

### DIFF
--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -140,11 +140,13 @@ defmodule Telepoison do
     span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> compute_default_span_name(request) end)
 
     resource_route = get_resource_route(opts, request)
+    %URI{host: host} = request.url |> process_request_url() |> URI.parse()
 
     attributes =
       [
         {"http.method", request.method |> Atom.to_string() |> String.upcase()},
-        {"http.url", request.url}
+        {"http.url", request.url},
+        {"net.peer.name", host}
       ] ++
         Keyword.get(opts, :ot_attributes, []) ++
         if resource_route != nil,

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -29,10 +29,11 @@ defmodule TelepoisonTest do
       assert_receive {:span, span(attributes: attributes_record)}
       attributes = elem(attributes_record, 4)
 
-      assert ["http.method", "http.status_code", "http.url"] ==
+      assert ["http.method", "http.status_code", "http.url", "net.peer.name"] ==
                attributes |> Map.keys() |> Enum.sort()
 
       assert {"http.method", "GET"} in attributes
+      assert {"net.peer.name", "localhost"} in attributes
     end
 
     test "traceparent header is injected when no headers" do


### PR DESCRIPTION
According to the [HTTP Client semantic conventions](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-client) this is a required attribute.