### PR TITLE
[RFQ-24]: Telepoison - add ability to set global configuratIon for 'standard' OT attributes

### DIFF
--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -231,10 +231,8 @@ defmodule Telepoison do
   defp get_attributes(opts) do
     case get_defaults() do
       {_, defaults} when is_list(defaults) ->
-        Keyword.get(opts, :ot_attributes, [])
-        |> then(fn attributes ->
-          Keyword.merge(attributes, defaults)
-        end)
+        attributes = Keyword.get(opts, :ot_attributes, [])
+        Keyword.merge(attributes, defaults)
 
       _ ->
         []

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -16,7 +16,7 @@ defmodule Telepoison do
   alias HTTPoison.Request
   alias OpenTelemetry.Tracer
 
-  @default_attributes [:env, :service, :service_name]
+  @default_attributes [:env, :service, :"service.name"]
 
   @doc ~S"""
   Configures Telepoison using the provided `opts` `Keyword list`.

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -171,13 +171,27 @@ defmodule TelepoisonTest do
       assert confirm_attributes(attributes, {"test_attribute", "test"})
     end
 
-    test "default attributes can be overridden via a two element tuple list passed to the Telepoison.invocation" do
+    test "default attributes can be overridden via a two element tuple list passed to the Telepoison invocation" do
       Telepoison.setup(ot_attributes: [{"test_attribute", "test"}])
 
       Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_attributes: [{"test_attribute", "overridden"}])
 
       assert_receive {:span, span(attributes: attributes)}, 1000
       assert confirm_attributes(attributes, {"test_attribute", "overridden"})
+    end
+
+    test "default attributes can be combined with attributes passed to the Telepoison invocation" do
+      Telepoison.setup(ot_attributes: [{"test_attribute", "test"}, {"test_attribute_overridden", "test"}])
+
+      Telepoison.get!("http://localhost:8000/user/edit/24", [],
+        ot_attributes: [{"another_test_attribute", "another test"}, {"test_attribute_overridden", "overridden"}]
+      )
+
+      assert_receive {:span, span(attributes: attributes)}, 1000
+
+      assert confirm_attributes(attributes, {"test_attribute", "test"})
+      assert confirm_attributes(attributes, {"another_test_attribute", "another test"})
+      assert confirm_attributes(attributes, {"test_attribute_overridden", "overridden"})
     end
 
     test "resource route can be implicitly inferred by Telepoison invocation" do

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -162,15 +162,6 @@ defmodule TelepoisonTest do
   end
 
   describe "Telepoison setup with additional configuration" do
-    test "default attributes can be set via a keyword list passed to Telepoison.setup/1" do
-      Telepoison.setup(ot_attributes: [test_attribute: "test"])
-
-      Telepoison.get!("http://localhost:8000/user/edit/24")
-
-      assert_receive {:span, span(attributes: attributes)}, 1000
-      assert confirm_attributes(attributes, {"test_attribute", "test"})
-    end
-
     test "default attributes can be set via a two element tuple list passed to Telepoison.setup/1" do
       Telepoison.setup(ot_attributes: [{"test_attribute", "test"}])
 
@@ -180,10 +171,10 @@ defmodule TelepoisonTest do
       assert confirm_attributes(attributes, {"test_attribute", "test"})
     end
 
-    test "default attributes can be overridden via a keyword list passed to the Telepoison.invocation" do
-      Telepoison.setup(ot_attributes: [test_attribute: "test"])
+    test "default attributes can be overridden via a two element tuple list passed to the Telepoison.invocation" do
+      Telepoison.setup(ot_attributes: [{"test_attribute", "test"}])
 
-      Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_attributes: [test_attribute: "overridden"])
+      Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_attributes: [{"test_attribute", "overridden"}])
 
       assert_receive {:span, span(attributes: attributes)}, 1000
       assert confirm_attributes(attributes, {"test_attribute", "overridden"})


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/RFQ-24

