### PR TITLE
[PLATFORM-992]: Ensure alignment of traces semantic convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If a function with an arity of 1 (the argument given being the `t:HTTPoison.Requ
 
 Both of these can be overridden per each call to Telepoison functions that wrap `Telepoison.request/1`, such as `Telepoison.get/3`, `Telepoison.get!/3`, `Telepoison.post/3` etc.
 
-See here for [examples](#Examples)
+See here for [examples](#examples)
 
 ## Open Telemetry integration
 
@@ -56,11 +56,11 @@ the `Keyword list` `opts` parameter (or the `t:HTTPoison.Request/0` `Keyword lis
 
 If the value is a string or an function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) that is used to set the attribute
 
-If `:infer` is provided, then the function discussed within the [Configuration](#Configuration) section is used to set the attribute
+If `:infer` is provided, then the function discussed within the [Configuration](#configuration) section is used to set the attribute
 
 If the atom `:ignore` is provided then the `http.route` attribute is ignored entirely
 
-**It is highly recommended** to supply the `:ot_resource_route` explicitly as either a string or a function with an arity of 1 (the `t:HTTPoison.Request/0` `request`) 
+**It is highly recommended** to supply the `:ot_resource_route` explicitly as either a string or a function with an arity of 1 (the `t:HTTPoison.Request/0` `request`)
 
 ## Examples
 
@@ -79,6 +79,7 @@ Telepoison.get!(
 ```
 
 In the example above:
+
 * `Telepoison.setup/1` is called with `{"service.name", "users"}` as the value for the `:ot_attributes` `Keyword list` option
 * `:infer` is passed as the value for the `:ot_resource_route` `Keyword list` option
 
@@ -97,6 +98,7 @@ Telepoison.get!(
 ```
 
 In the example above:
+
 * `Telepoison.setup/1` is called with `{"service.name", "users"}` as the value for the `:ot_attributes` `Keyword list` option
 * A `{"service.name", "userslist"}` `tuple` is provided to the `:ot_attributes` `Keyword list` option
 * `:infer` is passed as the value for the `:ot_resource_route` `Keyword list` option
@@ -116,6 +118,7 @@ Telepoison.get!(
 ```
 
 In the example above:
+
 * `Telepoison.setup/1` is called with no arguments
 * `:infer` is passed as the value for `:ot_resource_route` `Keyword list` option
 
@@ -136,6 +139,7 @@ Telepoison.get!(
 ```
 
 In the example above:
+
 * `Telepoison.setup/1` is called with the `:infer_route` `Keyword list` option set to a function which takes a `%HTTPoison.Request/0` argument, returning the path of the request URL
 * `:infer` is passed as the value for `:ot_resource_route` `Keyword list` option
 
@@ -152,6 +156,7 @@ Telepoison.get!(
 ```
 
 In the example above:
+
 * `Telepoison.setup/1` is called with no `Keyword list` options
 * `"my secret path"` is passed as the value for `:ot_resource_route` `Keyword list` option
 
@@ -168,6 +173,7 @@ Telepoison.get!(
 ```
 
 In the example above:
+
 * `Telepoison.setup/1` is called with no `Keyword list` options
 * `:ignore` is passed as the value for `:ot_resource_route` `Keyword list` option
 
@@ -178,7 +184,7 @@ Given the above, the `http.route` attribute will not be set to any value
 Telepoison, when executing an HTTP request to an external service, creates an OpenTelemetry span, injects
 the [trace context propagation headers](https://www.w3.org/TR/trace-context/) in the request headers, and
 ends the span once the response is received.
-It automatically sets some of the [HTTP span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md) like `http.status`, `http.host` etc,
+It automatically sets some of the [HTTP span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md) like `http.status` etc,
 based on the request and response data.
 
 Telepoison by itself is not particularly useful: it becomes useful when used in conjunction with a "server-side"

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -9,8 +9,9 @@ defmodule Telepoison do
   use HTTPoison.Base
 
   require OpenTelemetry
-  require OpenTelemetry.Tracer
+  require OpenTelemetry.SemanticConventions.Trace, as: Conventions
   require OpenTelemetry.Span
+  require OpenTelemetry.Tracer
   require Record
 
   alias HTTPoison.Request
@@ -150,7 +151,7 @@ defmodule Telepoison do
     resource_route = fn ->
       case get_resource_route(opts, request) do
         resource_route when is_binary(resource_route) ->
-          [{"http.route", resource_route}]
+          [{Conventions.http_route(), resource_route}]
 
         nil ->
           []
@@ -187,7 +188,7 @@ defmodule Telepoison do
       Tracer.set_status(:error, "")
     end
 
-    Tracer.set_attribute("http.status_code", status_code)
+    Tracer.set_attribute(Conventions.http_status_code(), status_code)
     end_span()
     status_code
   end
@@ -245,12 +246,12 @@ defmodule Telepoison do
 
   defp get_standard_ot_attributes(request, host) do
     [
-      {"http.method",
+      {Conventions.http_method(),
        request.method
        |> Atom.to_string()
        |> String.upcase()},
-      {"http.url", request.url},
-      {"net.peer.name", host}
+      {Conventions.http_url(), request.url},
+      {Conventions.net_peer_name(), host}
     ]
   end
 

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -150,7 +150,7 @@ defmodule Telepoison do
   def request(%Request{options: opts} = request) do
     save_parent_ctx()
 
-    span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> compute_default_span_name(request) end)
+    span_name = Keyword.get_lazy(opts, :ot_span_name, fn -> default_span_name(request) end)
 
     %URI{host: host} = request.url |> process_request_url() |> URI.parse()
 
@@ -204,7 +204,8 @@ defmodule Telepoison do
     restore_parent_ctx()
   end
 
-  def compute_default_span_name(request), do: request.method |> Atom.to_string() |> String.upcase()
+  # see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#name
+  def default_span_name(request), do: request.method |> Atom.to_string() |> String.upcase()
 
   @ctx_key {__MODULE__, :parent_ctx}
   defp save_parent_ctx do

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -17,6 +17,12 @@ defmodule Telepoison do
   alias HTTPoison.Request
   alias OpenTelemetry.Tracer
 
+  @http_url Atom.to_string(Conventions.http_url())
+  @http_method Atom.to_string(Conventions.http_method())
+  @http_route Atom.to_string(Conventions.http_route())
+  @http_status_code Atom.to_string(Conventions.http_status_code())
+  @net_peer_name Atom.to_string(Conventions.net_peer_name())
+
   @doc ~S"""
   Configures Telepoison using the provided `opts` `Keyword list`.
   You should call this function within your application startup, before Telepoison is used.
@@ -151,7 +157,7 @@ defmodule Telepoison do
     resource_route = fn ->
       case get_resource_route(opts, request) do
         resource_route when is_binary(resource_route) ->
-          [{Conventions.http_route(), resource_route}]
+          [{@http_route, resource_route}]
 
         nil ->
           []
@@ -188,7 +194,7 @@ defmodule Telepoison do
       Tracer.set_status(:error, "")
     end
 
-    Tracer.set_attribute(Conventions.http_status_code(), status_code)
+    Tracer.set_attribute(@http_status_code, status_code)
     end_span()
     status_code
   end
@@ -246,12 +252,12 @@ defmodule Telepoison do
 
   defp get_standard_ot_attributes(request, host) do
     [
-      {Conventions.http_method(),
+      {@http_method,
        request.method
        |> Atom.to_string()
        |> String.upcase()},
-      {Conventions.http_url(), request.url},
-      {Conventions.net_peer_name(), host}
+      {@http_url, request.url},
+      {@net_peer_name, host}
     ]
   end
 

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -204,11 +204,7 @@ defmodule Telepoison do
     restore_parent_ctx()
   end
 
-  def compute_default_span_name(request) do
-    method_str = request.method |> Atom.to_string() |> String.upcase()
-    %URI{authority: authority} = request.url |> process_request_url() |> URI.parse()
-    "#{method_str} #{authority}"
-  end
+  def compute_default_span_name(request), do: request.method |> Atom.to_string() |> String.upcase()
 
   @ctx_key {__MODULE__, :parent_ctx}
   defp save_parent_ctx do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Telepoison.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/telepoison"
-  @version "1.1.2"
+  @version "1.2.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Telepoison.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/telepoison"
-  @version "1.2.0"
+  @version "1.1.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Telepoison.MixProject do
   defp deps do
     [
       {:httpoison, "~> 1.6 or ~> 2.0"},
-      {:opentelemetry_api, "~> 1.0"}
+      {:opentelemetry_api, "~> 1.0"},
+      {:opentelemetry_semantic_conventions, "~> 0.2"},
     ] ++ dev_deps()
   end
 

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -26,7 +26,7 @@ defmodule TelepoisonTest do
     test "standard http client span attribute are set in span" do
       Telepoison.get!("http://localhost:8000")
 
-      assert_receive {:span, span(attributes: attributes_record)}
+      assert_receive {:span, span(attributes: attributes_record, name: "GET")}
       attributes = elem(attributes_record, 4)
 
       assert ["http.method", "http.status_code", "http.url", "net.peer.name"] ==
@@ -78,21 +78,21 @@ defmodule TelepoisonTest do
       assert confirm_attributes(attributes, {"http.route", "/user/edit/24"})
     end
 
-    test "resource route inferrence can be explicitly ignored" do
+    test "resource route inference can be explicitly ignored" do
       Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: :ignore)
 
       assert_receive {:span, span(attributes: attributes)}, 1000
       refute confirm_http_route_attribute(attributes)
     end
 
-    test "resource route inferrence can be implicitly ignored" do
+    test "resource route inference can be implicitly ignored" do
       Telepoison.get!("http://localhost:8000/user/edit/24")
 
       assert_receive {:span, span(attributes: attributes)}, 1000
       refute confirm_http_route_attribute(attributes)
     end
 
-    test "resource route inferrence fails if an incorrect value is passed to the Telepoison invocation" do
+    test "resource route inference fails if an incorrect value is passed to the Telepoison invocation" do
       assert_raise(ArgumentError, fn ->
         Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_resource_route: nil)
       end)


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-995

This PR adds the [opentelemetry_semantic_conventions](https://hexdocs.pm/opentelemetry_semantic_conventions/0.2.0/) library as a dependency to ensure we follow the proper convention names

