### PR TITLE
[PLATFORM-1004]: Debug 1.2.0 failing to start

### DIFF
--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -300,7 +300,7 @@ defmodule Telepoison do
   end
 
   defp get_defaults(:infer_fn) do
-    if is_agent_started?() do
+    if agent_started?() do
       Agent.get(
         __MODULE__,
         fn
@@ -317,7 +317,7 @@ defmodule Telepoison do
   end
 
   defp get_defaults(:ot_attributes) do
-    if is_agent_started?() do
+    if agent_started?() do
       attributes =
         Agent.get(
           __MODULE__,
@@ -336,7 +336,7 @@ defmodule Telepoison do
     end
   end
 
-  defp is_agent_started?, do: Process.whereis(__MODULE__) != nil
+  defp agent_started?, do: Process.whereis(__MODULE__) != nil
 
   defp strip_uri_credentials(uri) do
     uri |> URI.parse() |> Map.put(:userinfo, nil) |> Map.put(:authority, nil) |> URI.to_string()

--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -336,7 +336,7 @@ defmodule Telepoison do
     end
   end
 
-  defp is_agent_started?(), do: Process.whereis(__MODULE__) != nil
+  defp is_agent_started?, do: Process.whereis(__MODULE__) != nil
 
   defp strip_uri_credentials(uri) do
     uri |> URI.parse() |> Map.put(:userinfo, nil) |> Map.put(:authority, nil) |> URI.to_string()

--- a/test/telepoison_test.exs
+++ b/test/telepoison_test.exs
@@ -252,6 +252,14 @@ defmodule TelepoisonTest do
     end
   end
 
+  test "Telepoison works if setup is not called" do
+    Telepoison.get!("http://localhost:8000/user/edit/24", [], ot_attributes: [{"some_attribute", "some value"}])
+
+    assert_receive {:span, span(attributes: attributes)}, 1000
+
+    assert confirm_attributes(attributes, {"some_attribute", "some value"})
+  end
+
   def flush_mailbox do
     receive do
       _ -> flush_mailbox()


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1004

This PR fixes the regression in 1.2.0 which causes Telepoison not to work if `setup` is not called.

