### PR TITLE
Adopt latest semantic conventions

### DIFF
--- a/lib/telepoison.ex
+++ b/lib/telepoison.ex
@@ -19,10 +19,10 @@ defmodule Telepoison do
   alias OpenTelemetry.Tracer
   alias Telepoison.Configuration
 
-  @http_url Atom.to_string(Conventions.http_url())
   @http_method Atom.to_string(Conventions.http_method())
   @http_route Atom.to_string(Conventions.http_route())
   @http_status_code Atom.to_string(Conventions.http_status_code())
+  @http_url Atom.to_string(Conventions.http_url())
   @net_peer_name Atom.to_string(Conventions.net_peer_name())
 
   @doc ~S"""


### PR DESCRIPTION
This adopts the latest semantic conventions, version 1.26.0, and keeps what's already there.

Notably, this pull request makes the following [HTTP client span attributes](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client) available:

- `http.request.method`
- `http.response.status_code`
- `server.address`
- `server.port`
- `url.full`
- `url.scheme`

There are no constants available for these yet. open-telemetry/opentelemetry-erlang#733 is currently a draft.

See also [this summary of changes](https://opentelemetry.io/docs/specs/semconv/http/migration-guide/#summary-of-changes) and [the list of deprecated attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-deprecated-attributes).

I'll note that [the migration guide](https://opentelemetry.io/docs/specs/semconv/http/migration-guide/) suggests defining the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable to allow opting in to the new set. That seems unnecessarily complicated to me but happy to follow that advise if you prefer.

I think the simpler approach is this:

- The current release, version 1.3.1, contains the old set of attributes ("default behavior")
- The next release, version 1.3.2, contains both the old and the new set of attributes (`http/dup` equivalent)
- The next major release contains only the new set of attributes (`http` equivalent)

The benefit of making these available already is that anyone adopting Telepoison today can use the latest conventions already and for existing users, double-writing allows for a seamless migration.